### PR TITLE
Support Postgres 96

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+clean text eol=lf
+pgsql-http-rpm text eol=lf
+SPECS/pgsql-http-*.spec text eol=lf

--- a/SPECS/pgsql-http-96.spec
+++ b/SPECS/pgsql-http-96.spec
@@ -1,0 +1,58 @@
+Name:           postgresql-96-pgsql-http
+Version:        1.1.2
+Release:        1%{?dist}
+Summary:        HTTP client for PostgreSQL, retrieve a web page from inside the database.
+
+License:        None
+URL:            https://github.com/pramsey/pgsql-http
+Source:         https://github.com/pramsey/pgsql-http/archive/v%{version}.tar.gz
+
+Requires:       postgresql96 >= 9.6.2
+Requires:       postgresql96-server >= 9.6.2
+Requires:       postgresql96-libs >= 9.6.2
+
+BuildRequires:  postgresql96-devel
+BuildRequires:  curl-devel >= 0.7.20
+BuildRequires:	make, gcc
+
+%description
+HTTP client for PostgreSQL, retrieve a web page from inside the database.
+
+%global debug_package %{nil}
+
+%prep
+%setup -q -n pgsql-http-%{version}
+
+
+%build
+PATH=/usr/pgsql-9.6/bin:$PATH make
+
+%install
+rm -rf %{buildroot}
+PATH=/usr/pgsql-9.6/bin:$PATH make install DESTDIR=%{buildroot}
+mkdir -p %{buildroot}/usr/share/doc/%{name}
+cp README.md %{buildroot}/usr/share/doc/%{name}/README.md
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%attr(755, root, root)/usr/pgsql-9.6/lib/http.so
+%attr(644, root, root)/usr/pgsql-9.6/share/extension/http--1.1.sql
+%attr(644, root, root)/usr/pgsql-9.6/share/extension/http--1.0--1.1.sql
+%attr(644, root, root)/usr/pgsql-9.6/share/extension/http.control
+
+%doc /usr/share/doc/%{name}/README.md
+
+
+
+%changelog
+
+* Sun Jul 30 2017 Kevin Shaw <shawmanz32na@gmail.com> - 1.1.2-1
+- 1.1.2 build from https://github.com/pramsey/pgsql-http
+
+* Fri Sep 30 2016 Julio Gonzalez Gil <git@juliogonzalez.es> - 1.1.1-2gita58d9d2
+- Build from commit a58d9d2 (latest available)
+
+* Fri Jul 08 2016 Julio Gonzalez Gil <git@juliogonzalez.es> - 1.1.1
+- 1.1.1 build from https://github.com/pramsey/pgsql-http

--- a/pgsql-http-rpm
+++ b/pgsql-http-rpm
@@ -3,7 +3,7 @@
 SCRIPT=$(basename ${0})
 MODULE_VER="1.1.2"
 GIT_VER=""
-VERSIONS="9.2 9.3 9.4"
+VERSIONS="9.2 9.3 9.4 9.6"
 
 function help() {
   echo ""


### PR DESCRIPTION
First of all, thanks for building this in the first place - it came in super handy for our team.

We needed to target Postgres 9.6 with pgsql-http, so I've added the new spec and supporting README details for building an RPM for pgsql-http 1.1.2 for PostgreSQL 9.6.2+

I wasn't quite sure how to handle the `%changelog` section, as I've added support for a new version of Postgres, but haven't changed any functionality. I'd like to leave it to you if this requires a version bump or not.

If it helps, I work on Windows (in case you didn't figure it out from my commit of a .gitattributes file), so built a simple Docker image to test and build the RPM at https://github.com/shawmanz32na/pgsql-http-rpm-build-environment. I'm not sure if this can be reused in any way, but it should at least give you an idea of my testing environment.